### PR TITLE
Fix auto-release: use RELEASE_TOKEN to bypass branch protection

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -65,7 +65,11 @@ jobs:
         with:
           ref: master
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # RELEASE_TOKEN is a fine-grained PAT with Contents:write scope,
+          # required to bypass branch protection when pushing the CHANGELOG
+          # commit and the new tag to master. The default GITHUB_TOKEN
+          # cannot bypass `required_pull_request_reviews`.
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Configure git as github-actions[bot]
         run: |


### PR DESCRIPTION
## Problem

The first manual trigger of \`auto-release.yml\` (from PR #78) failed at the push-to-master step:

\`\`\`
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - Changes must be made through a pull request.
remote: - 2 of 2 required status checks are expected.
\`\`\`

The default \`GITHUB_TOKEN\` cannot bypass master's branch protection (\`required_pull_request_reviews\` + \`required_status_checks\`).

## Fix

Switch the checkout token in \`auto-release.yml\` to a fine-grained PAT stored as repo secret \`RELEASE_TOKEN\` (Contents:Read+Write scope on this repo only). The PAT bypasses branch protection on push of the CHANGELOG commit and the new tag.

\`GH_TOKEN\` for \`gh pr list\` keeps using \`GITHUB_TOKEN\` — read-only API calls don't need elevated permissions.

## Verification

After merge: re-run \`Auto Release\` workflow manually. The CHANGELOG commit + tag push should now succeed, triggering \`release.yml\` and creating the GitHub Release for v12.2.0 (or whatever bump applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)