### PR TITLE
Allow bot-authored PRs in Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,11 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # Allow bot-authored PRs (Renovate, Dependabot, etc.) to be reviewed.
+          # Without this, the action refuses to run on non-human actors and
+          # leaves the check in a failed state — which would block any merge
+          # if claude-review is added to required status checks on master.
+          allowed_bots: '*'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Problem

The Claude Code Review workflow currently fails on every bot-authored PR (Renovate, Dependabot, etc.) with:

\`\`\`
Workflow initiated by non-human actor: renovate (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
\`\`\`

This is a blocker for promoting \`claude-review\` to a required status check on master — every Renovate dependency-update PR would become unmergeable.

## Fix

Add \`allowed_bots: '*'\` to the action input in \`.github/workflows/claude-code-review.yml\`.

\`*\` is appropriate for this small public package where bot PRs are part of normal flow and there's no concern about quota exhaustion from external bots.

## Diff

\`.github/workflows/claude-code-review.yml\` only — 5 added lines.

## Verification

After merge: open a Renovate update PR (or wait for the next one) and confirm the \`claude-review\` job runs to completion instead of failing on actor check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)